### PR TITLE
Fix: Support Avanza 2025 header and QOL improvements

### DIFF
--- a/hava.cabal
+++ b/hava.cabal
@@ -51,6 +51,9 @@ library
   hs-source-dirs:
       app
       src
+  default-extensions:
+      OverloadedStrings
+      RecordWildCards
   build-depends:
       base >=4.7 && <5
     , bytestring
@@ -77,6 +80,9 @@ executable hava-exe
       Paths_hava
   hs-source-dirs:
       app
+  default-extensions:
+      OverloadedStrings
+      RecordWildCards
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
@@ -105,6 +111,9 @@ test-suite hava-test
       Paths_hava
   hs-source-dirs:
       test
+  default-extensions:
+      OverloadedStrings
+      RecordWildCards
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5

--- a/hava.cabal
+++ b/hava.cabal
@@ -108,6 +108,7 @@ test-suite hava-test
       CalcSpec
       ParseSpec
       TablesSpec
+      TestUtils
       Paths_hava
   hs-source-dirs:
       test

--- a/package.yaml
+++ b/package.yaml
@@ -33,6 +33,10 @@ dependencies:
   - hspec
   - terminal-size
 
+default-extensions:
+  - OverloadedStrings
+  - RecordWildCards
+
 library:
   source-dirs:
     - app

--- a/src/Parse.hs
+++ b/src/Parse.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE OverloadedStrings #-}
 
 module Parse
   ( parseCsvData,
@@ -9,20 +8,9 @@ module Parse
 where
 
 -- bytestring
-import Data.ByteString.Char8 as BS (ByteString, pack)
-import Data.ByteString.Lazy as BSL
-  ( drop,
-    take,
-    toStrict,
-  )
-import qualified Data.ByteString.Lazy as ByteString hiding
-  ( putStrLn,
-  )
-import Data.ByteString.Lazy.Char8 as BSL (pack, unpack)
-import Data.ByteString.Lazy.Search as BSL ()
-import Data.ByteString.Lazy.UTF8 as BLU (fromString)
-import Data.ByteString.Search as BS (replace)
-import Data.ByteString.UTF8 as BU (fromString)
+import qualified Data.ByteString      as BS       -- strict bytes (Word8 API)
+import qualified Data.ByteString.Lazy as BSL       -- lazy bytes
+import qualified Data.ByteString.UTF8 as BSU      -- UTF-8 <-> String helpers
 -- other
 import Data.Char (chr, ord)
 import Data.Csv
@@ -39,19 +27,37 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Vector as V
+import qualified Data.List as L
 -- Types
 import Types.Money (Money (..))
 import Types.Transaction.GenericTransaction
   ( GenericTransaction (..),
     Transaction (..),
   )
+import System.Exit (die)
+import qualified Codec.Binary.UTF8.Generic as BS
+import           Data.Word (Word8)
+
+expectedHeaders :: [BS.ByteString]
+expectedHeaders = map BS.fromString
+  [ "Datum"
+  , "Konto"
+  , "Typ av transaktion"
+  , "Värdepapper/beskrivning"
+  , "Antal"
+  , "Kurs"
+  , "Belopp"
+  , "Courtage"
+  , "Instrumentvaluta"
+  , "ISIN"
+  ]
 
 instance FromNamedRecord Transaction where
   parseNamedRecord r = do
     date      <- r .: "Datum"
     account   <- r .: "Konto"
     action    <- r .: "Typ av transaktion"
-    company   <- r .: BU.fromString "Värdepapper/beskrivning"
+    company   <- r .: BSU.fromString "Värdepapper/beskrivning"
     quantity  <- r .: "Antal"
     rate      <- r .: "Kurs"
     amount    <- r .: "Belopp"
@@ -63,14 +69,44 @@ instance FromNamedRecord Transaction where
 
 -- Note: "resultat" avilable but not parsed at this time
 
-parseCsvData :: ByteString.ByteString -> [Transaction]
-parseCsvData csvData = case decodeByNameWith decOptions (dropBOM csvData) of
-  Left err -> error err
-  Right (h, v) -> V.toList v
-  where
-    decOptions = defaultDecodeOptions {decDelimiter = fromIntegral (ord ';')}
+parseCsvData :: BSL.ByteString -> [Transaction]
+parseCsvData csvData =
+  let withoutBom = dropBOM csvData
+      header = readHeader withoutBom
+      decOptions = defaultDecodeOptions {decDelimiter = fromIntegral (ord ';')}
+  in case checkHeadersStrict header of
+    Just msg -> error msg
+    Nothing -> case decodeByNameWith decOptions withoutBom of
+      Left err -> error err
+      Right (h, v) -> V.toList v
 
-dropBOM :: ByteString.ByteString -> ByteString.ByteString
+dropBOM :: BSL.ByteString -> BSL.ByteString
 dropBOM x
-  | BSL.take 3 x == BSL.pack (map chr [0xEF, 0xBB, 0xBF]) = BSL.drop 3 x
+  | BSL.take 3 x == BSL.pack (map (fromIntegral . fromEnum) ['\239','\187','\191']) = BSL.drop 3 x
   | otherwise = x
+
+readHeader :: BSL.ByteString -> [BS.ByteString]
+readHeader bs =
+  let (hdr, _) = BSL.break (== nl) bs
+  in BS.split semi (BSL.toStrict hdr)
+
+checkHeadersStrict :: [BS.ByteString] -> Maybe String
+checkHeadersStrict found =
+  if all (`elem` found) expectedHeaders
+     then Nothing
+     else
+       let missing = filter (`notElem` found) expectedHeaders
+           extra   = filter (`notElem` expectedHeaders) found
+           pretty  = L.intercalate ", "
+           s       = map BS.toString
+       in Just $ unlines
+            [ "Unexpected CSV header."
+            , "Missing: " <> pretty (s missing)
+            , "Extra:   " <> pretty (s extra)
+            , "Expected headers:\n" <> unlines (map ("  " <>) (s expectedHeaders))
+            , "Found headers:\n"    <> unlines (map ("  " <>) (s found))
+            ]
+-- Delimiters as Word8
+semi, nl :: Word8
+semi = 59  -- ';'
+nl   = 10  -- '\n'

--- a/src/Parse.hs
+++ b/src/Parse.hs
@@ -46,36 +46,22 @@ import Types.Transaction.GenericTransaction
     Transaction (..),
   )
 
-avanzaCsvHeader2024 :: String
-avanzaCsvHeader2024 = "Datum;Konto;Typ av transaktion;Värdepapper/beskrivning;Antal;Kurs;Belopp;Transaktionsvaluta;Courtage (SEK);Valutakurs;Instrumentvaluta;ISIN;Resultat"
-
 instance FromNamedRecord Transaction where
-  parseNamedRecord r =
-    GenericTransaction
-      <$> r
-        .: "Datum"
-      <*> r
-        .: "Konto"
-      <*> r
-        .: "Typ av transaktion"
-      <*> r
-        .: BU.fromString "Värdepapper/beskrivning"
-      <*> r
-        .: "Antal"
-      <*> r
-        .: "Kurs"
-      <*> r
-        .: "Belopp"
-      -- trans valuta
-      <*> r
-        .: "Courtage (SEK)"
-      -- valuta-kurs
-      <*> r
-        .: "Instrumentvaluta"
-      <*> r
-        .: "ISIN"
+  parseNamedRecord r = do
+    date      <- r .: "Datum"
+    account   <- r .: "Konto"
+    action    <- r .: "Typ av transaktion"
+    company   <- r .: BU.fromString "Värdepapper/beskrivning"
+    quantity  <- r .: "Antal"
+    rate      <- r .: "Kurs"
+    amount    <- r .: "Belopp"
+    courtage  <- r .: "Courtage"
+    currency  <- r .: "Instrumentvaluta"
+    isin      <- r .: "ISIN"
 
--- resultat
+    return GenericTransaction {..}
+
+-- Note: "resultat" avilable but not parsed at this time
 
 parseCsvData :: ByteString.ByteString -> [Transaction]
 parseCsvData csvData = case decodeByNameWith decOptions (dropBOM csvData) of

--- a/src/Parse.hs
+++ b/src/Parse.hs
@@ -28,18 +28,17 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Vector as V
 import qualified Data.List as L
+import System.Exit (die)
+import           Data.Word (Word8)
 -- Types
 import Types.Money (Money (..))
 import Types.Transaction.GenericTransaction
   ( GenericTransaction (..),
     Transaction (..),
   )
-import System.Exit (die)
-import qualified Codec.Binary.UTF8.Generic as BS
-import           Data.Word (Word8)
 
-expectedHeaders :: [BS.ByteString]
-expectedHeaders = map BS.fromString
+expectedHeaders :: [BSU.ByteString]
+expectedHeaders = map BSU.fromString
   [ "Datum"
   , "Konto"
   , "Typ av transaktion"
@@ -98,7 +97,7 @@ checkHeadersStrict found =
        let missing = filter (`notElem` found) expectedHeaders
            extra   = filter (`notElem` expectedHeaders) found
            pretty  = L.intercalate ", "
-           s       = map BS.toString
+           s       = map BSU.toString
        in Just $ unlines
             [ "Unexpected CSV header."
             , "Missing: " <> pretty (s missing)
@@ -106,6 +105,7 @@ checkHeadersStrict found =
             , "Expected headers:\n" <> unlines (map ("  " <>) (s expectedHeaders))
             , "Found headers:\n"    <> unlines (map ("  " <>) (s found))
             ]
+
 -- Delimiters as Word8
 semi, nl :: Word8
 semi = 59  -- ';'

--- a/src/Types/Transaction/TransactionBuySell.hs
+++ b/src/Types/Transaction/TransactionBuySell.hs
@@ -43,16 +43,12 @@ transformToBuySell (GenericTransaction date account action company quantity rate
 
     return $
       GenericTransaction
-        { date = date,
-          account = account,
-          action = action',
-          company = company,
+        { action = action',
           quantity = quantity',
           rate = rate',
           amount = amount',
           courtage = courtage',
-          currency = currency,
-          isin = isin
+          ..
         }
 
 instance SortableByDate TransactionBuySell where

--- a/src/Types/Transaction/TransactionDividend.hs
+++ b/src/Types/Transaction/TransactionDividend.hs
@@ -37,14 +37,10 @@ transformToDividend (GenericTransaction date account action company quantity rat
 
     return $
       GenericTransaction
-        { date = date,
-          account = account,
-          action = action',
-          company = company,
+        { action = action',
           quantity = quantity',
           rate = rate',
           amount = amount',
           courtage = courtage',
-          currency = currency,
-          isin = isin
+          ..
         }

--- a/src/Types/Transaction/TransactionSplit.hs
+++ b/src/Types/Transaction/TransactionSplit.hs
@@ -32,14 +32,10 @@ transformToSplit (GenericTransaction date account action company quantity rate a
 
     return $
       GenericTransaction
-        { date = date,
-          account = account,
-          action = action',
-          company = company,
+        { action = action',
           quantity = quantity',
           rate = (),
           amount = (),
           courtage = (),
-          currency = currency,
-          isin = isin
+          ..
         }

--- a/test/ParseSpec.hs
+++ b/test/ParseSpec.hs
@@ -22,7 +22,7 @@ testBasicParsing = do
     -- Populate with header row twice so that the header will be pared into
     -- Generic transaction. We can then make sure the values get parsed into
     -- the expected fields
-    let row = stringsToCsvByteString [csvHeader2024, csvHeader2024]
+    let row = stringsToCsvByteString [csvHeader2025, csvHeader2025]
     let expected =
           [ GenericTransaction
               { date = T.pack "Datum",
@@ -32,7 +32,7 @@ testBasicParsing = do
                 quantity = T.pack "Antal",
                 rate = T.pack "Kurs",
                 amount = T.pack "Belopp",
-                courtage = T.pack "Courtage (SEK)",
+                courtage = T.pack "Courtage",
                 currency = T.pack "Instrumentvaluta",
                 isin = T.pack "ISIN"
               }
@@ -44,7 +44,7 @@ testParseBuy = do
   it "should parse buy transaction" $ do
     let withBuyRow =
           stringsToCsvByteString
-            [ csvHeader2024,
+            [ csvHeader2025,
               "2024-01-01;1111111;Köp;Company A;5;100;-500;SEK;7;;SEK;some-isin;"
             ]
     let expectedGenericTransaction =
@@ -73,6 +73,9 @@ csvHeader = "Datum;Konto;Typ av transaktion;Värdepapper/beskrivning;Antal;Kurs;
 
 csvHeader2024 :: String
 csvHeader2024 = "Datum;Konto;Typ av transaktion;Värdepapper/beskrivning;Antal;Kurs;Belopp;Transaktionsvaluta;Courtage (SEK);Valutakurs;Instrumentvaluta;ISIN;Resultat"
+
+csvHeader2025 :: String
+csvHeader2025 = "Datum;Konto;Typ av transaktion;Värdepapper/beskrivning;Antal;Kurs;Belopp;Transaktionsvaluta;Courtage;Valutakurs;Instrumentvaluta;ISIN;Resultat"
 
 stringsToCsvByteString :: [String] -> UTF8.ByteString
 stringsToCsvByteString rows = UTF8.fromString $ unlines rows

--- a/test/ParseSpec.hs
+++ b/test/ParseSpec.hs
@@ -3,16 +3,16 @@ module ParseSpec
   )
 where
 
+import Control.Exception (ErrorCall (ErrorCall), evaluate)
 import qualified Data.ByteString.Lazy.UTF8 as UTF8
+import Data.List (isInfixOf)
 import Data.Maybe (isJust)
 import qualified Data.Text as T
 import qualified Parse as P
 import Test.Hspec
+import TestUtils (shouldThrowErrorContaining)
 import Types.Transaction.GenericTransaction (GenericTransaction (..))
 import Types.Transaction.TransactionBuySell (transformToBuySell)
-import Control.Exception (evaluate, ErrorCall (ErrorCall))
-import Data.List (isInfixOf)
-import TestUtils (shouldThrowErrorContaining)
 
 spec :: Spec
 spec = do
@@ -45,17 +45,17 @@ testBasicParsing = do
   it "fails with a friendly message if a required header is missing" $ do
     let badHeader =
           "Datum-with-extra-chars;Konto;Typ av transaktion;Värdepapper/beskrivning;Antal;Kurs;Belopp;Courtage;Instrumentvaluta;ISIN"
-    let csv = stringsToCsvByteString [badHeader] 
+    let csv = stringsToCsvByteString [badHeader]
 
-    evaluate (P.parseCsvData csv) 
-      `shouldThrowErrorContaining` "Unexpected CSV header." 
+    evaluate (P.parseCsvData csv)
+      `shouldThrowErrorContaining` "Unexpected CSV header."
 
     evaluate (P.parseCsvData csv)
       `shouldThrowErrorContaining` "Missing: Datum"
 
     evaluate (P.parseCsvData csv)
-       -- Note: 2 extra spaces is expected after "Extra" to align with "Missing"
-      `shouldThrowErrorContaining` "Extra:   Datum-with-extra-chars" 
+      -- Note: 2 extra spaces is expected after "Extra" to align with "Missing"
+      `shouldThrowErrorContaining` "Extra:   Datum-with-extra-chars"
 
 testParseBuy :: Spec
 testParseBuy = do

--- a/test/TestUtils.hs
+++ b/test/TestUtils.hs
@@ -1,0 +1,11 @@
+module TestUtils (
+  shouldThrowErrorContaining
+) where 
+
+import Control.Exception (ErrorCall(..))
+import Test.Hspec 
+import Data.List (isInfixOf)
+
+shouldThrowErrorContaining :: IO a -> String -> Expectation
+shouldThrowErrorContaining action str =
+  action `shouldThrow` \(ErrorCall msg) -> str `isInfixOf` msg

--- a/test/TestUtils.hs
+++ b/test/TestUtils.hs
@@ -1,10 +1,11 @@
-module TestUtils (
-  shouldThrowErrorContaining
-) where 
+module TestUtils
+  ( shouldThrowErrorContaining,
+  )
+where
 
-import Control.Exception (ErrorCall(..))
-import Test.Hspec 
+import Control.Exception (ErrorCall (..))
 import Data.List (isInfixOf)
+import Test.Hspec
 
 shouldThrowErrorContaining :: IO a -> String -> Expectation
 shouldThrowErrorContaining action str =


### PR DESCRIPTION
fix/feat: support avanza 2025 csv header (move from courtage (SEK) -> courtage)

chore: allow lang extension RecordWildCards and OverloadedStrings everywhere and use it where applicable

feat: validate csv header and give a helpful error message if it doesn't look like expected

test: test "validate csv header" during parsing

chore: cleanup bytestring mess in Parse module